### PR TITLE
Add 404 page and fix settings link

### DIFF
--- a/app.py
+++ b/app.py
@@ -1715,3 +1715,9 @@ def handle_subscription_cancellation(subscription):
     
     conn.commit()
     conn.close()
+
+
+@app.errorhandler(404)
+def page_not_found(e):
+    """Render custom 404 page"""
+    return render_template('404.html'), 404

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% block title %}Page Not Found - Sapyyn{% endblock %}
+{% block content %}
+<div class="container text-center mt-5">
+    <h1 class="display-4 text-danger">404</h1>
+    <p class="lead">The page you are looking for does not exist.</p>
+    <a href="{{ url_for('index') }}" class="btn btn-primary">
+        <i class="bi bi-house me-2"></i>Return Home
+    </a>
+</div>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -61,8 +61,8 @@
                             {{ session.full_name or session.username }}
                         </a>
                         <ul class="dropdown-menu">
-                            <li><a class="dropdown-item" href="#"><i class="bi bi-person"></i> Profile</a></li>
-                            <li><a class="dropdown-item" href="#"><i class="bi bi-gear"></i> Settings</a></li>
+                            <li><a class="dropdown-item" href="{{ url_for('profile') }}"><i class="bi bi-person"></i> Profile</a></li>
+                            <li><a class="dropdown-item" href="{{ url_for('settings') }}"><i class="bi bi-gear"></i> Settings</a></li>
                             <li><hr class="dropdown-divider"></li>
                             <li><a class="dropdown-item" href="{{ url_for('logout') }}"><i class="bi bi-box-arrow-right"></i> Logout</a></li>
                         </ul>


### PR DESCRIPTION
## Summary
- fix dropdown menu links to Profile and Settings
- add custom 404 page template
- render 404 page from new error handler

## Testing
- `python -m py_compile app.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68731c31eb4c8328a765b5cd81e3e921