### PR TITLE
Failed sapyyn dependency installation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,9 +5,6 @@ Flask-WTF==1.2.1
 Flask-Limiter==3.5.0
 Flask-Mail==0.9.1
 
-# Database
-sqlite3
-
 # Payment processing
 stripe==6.6.0
 
@@ -56,13 +53,3 @@ gevent==23.9.1
 
 # Monitoring
 sentry-sdk[flask]==1.38.0
-
-# Utilities
-uuid==1.30
-base64
-io
-datetime
-os
-random
-string
-hashlib


### PR DESCRIPTION
Remove built-in Python modules from `requirements.txt` to resolve build failures.

The build was failing because `sqlite3` and other built-in modules were listed as pip dependencies, which cannot be installed this way.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-b92438dc-b40c-46e0-9553-de5bf5c8b313) · [Cursor](https://cursor.com/background-agent?bcId=bc-b92438dc-b40c-46e0-9553-de5bf5c8b313)