### PR TITLE
Failed sapyyn dependency installation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ Flask-Limiter==3.5.0
 Flask-Mail==0.9.1
 
 # Database
-sqlite3
 
 # Payment processing
 stripe==6.6.0
@@ -58,11 +57,3 @@ gevent==23.9.1
 sentry-sdk[flask]==1.38.0
 
 # Utilities
-uuid==1.30
-base64
-io
-datetime
-os
-random
-string
-hashlib


### PR DESCRIPTION
Remove standard library modules from `requirements.txt` to fix pip installation errors.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-ddd15f57-9d7d-4943-8673-38bb76c8e506) · [Cursor](https://cursor.com/background-agent?bcId=bc-ddd15f57-9d7d-4943-8673-38bb76c8e506)