### PR TITLE
Sapyyn application build failed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,9 +5,6 @@ Flask-WTF==1.2.1
 Flask-Limiter==3.5.0
 Flask-Mail==0.9.1
 
-# Database
-sqlite3
-
 # Payment processing
 stripe==6.6.0
 
@@ -56,13 +53,3 @@ gevent==23.9.1
 
 # Monitoring
 sentry-sdk[flask]==1.38.0
-
-# Utilities
-uuid==1.30
-base64
-io
-datetime
-os
-random
-string
-hashlib


### PR DESCRIPTION
Remove built-in Python modules from `requirements.txt` to fix build failures.

The build was failing because `requirements.txt` incorrectly listed built-in Python modules (e.g., `sqlite3`, `uuid`, `base64`) as dependencies. These modules are part of Python's standard library and do not need to be installed via pip, causing the build to fail when pip could not find distributions for them. Removing them resolves the dependency installation error.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-ecf5c695-66c0-4b4a-912b-6948897940e8) · [Cursor](https://cursor.com/background-agent?bcId=bc-ecf5c695-66c0-4b4a-912b-6948897940e8)