### PR TITLE
Sapyyn application build failure

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,8 +2,9 @@
 # Complete routing configuration for all pages
 
 [build]
-  command = "echo 'Building Sapyyn application...' && cp -r static/* ."
+  command = "echo 'Building Sapyyn application...' && if [ -d static ]; then cp -r static/* .; fi"
   publish = "."
+  environment = { PYTHON_VERSION = "3.12" }
 
 # ===========================
 # MAIN PAGES & ROUTING

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ Flask-WTF==1.2.1
 stripe==6.6.0
 qrcode[pil]==7.4.2
 python-dotenv==1.0.0
-Pillow==10.0.1
+Pillow==11.0.0
 requests==2.31.0
 gunicorn==21.2.0


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix Netlify build failure due to Pillow and Python 3.13 incompatibility.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The build was failing with a `KeyError: '__version__'` during Pillow installation, stemming from a known incompatibility between Pillow 10.x and Python 3.13. This PR addresses the issue by:
- Updating `Pillow` to version `11.0.0` in `requirements.txt` (which supports Python 3.13).
- Explicitly setting `PYTHON_VERSION = "3.12"` in `netlify.toml` to ensure a stable and compatible Python environment on Netlify.
- Making the build command more robust by conditionally copying static files.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents%3Fid=bc-b782928e-5766-4969-8ece-aee3b24d9f07) · [Cursor](https://cursor.com/background-agent%3FbcId=bc-b782928e-5766-4969-8ece-aee3b24d9f07)